### PR TITLE
First name instead of 'Profile' in right corner of header

### DIFF
--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -52,7 +52,12 @@ export default function LoginButton(props) {
     bgcolor: cybTheme.palette.primary.main,
   };
   
-  
+  const buttonText = () => {
+    if (session.data != undefined) {
+      return session.data.user.name.split(" ")[0]
+    }
+    return "Login"
+  }
   
   return (
     <>
@@ -84,7 +89,7 @@ export default function LoginButton(props) {
                 }}
                 primary={
                   <Typography variant="caption">
-                    {session.data != undefined ? "Profile" : "Login"}
+                    {buttonText()}
                   </Typography>
                 }
               />
@@ -109,7 +114,7 @@ export default function LoginButton(props) {
                 // color={cybTheme.palette.text.secondary}
                 sx={{ display: { xs: "none", md: "flex" } }}
               >
-                {session.data != undefined ? "Profile" : "Login"}
+                {buttonText()}
               </Typography>
 
               {session.status == "authenticated" ? (
@@ -122,7 +127,7 @@ export default function LoginButton(props) {
               ) : (
                 <Avatar sx={{ ...avatarProps }}>
                   <Person
-                    color={cybTheme.palette.background.main}
+                      color={cybTheme.palette.background.main}
                     // color= sx={{
                     //   color: cybTheme.palette.background.main
                     //   }}

--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -110,7 +110,6 @@ export default function LoginButton(props) {
             >
               <Typography
                 variant="body1"
-                width="3em"
                 // color={cybTheme.palette.text.secondary}
                 sx={{ display: { xs: "none", md: "flex" } }}
               >

--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -55,9 +55,9 @@ export default function LoginButton(props) {
   const buttonText = () => {
     if (session.data != undefined) {
       let firstName = session.data.user.name.split(" ")[0]
-      // Shorten the first name if it is longer than 25 characters
-      if (firstName.length > 25) {
-        firstName = firstName.slice(0, 22) + "..."
+      // Shorten the first name if it is longer than 15 characters
+      if (firstName.length > 15) {
+        firstName = firstName.slice(0, 12) + "..."
       }
       return firstName
     }

--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -54,7 +54,12 @@ export default function LoginButton(props) {
   
   const buttonText = () => {
     if (session.data != undefined) {
-      return session.data.user.name.split(" ")[0]
+      let firstName = session.data.user.name.split(" ")[0]
+      // Shorten the first name if it is longer than 25 characters
+      if (firstName.length > 25) {
+        firstName = firstName.slice(0, 22) + "..."
+      }
+      return firstName
     }
     return "Login"
   }

--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -54,7 +54,7 @@ export default function LoginButton(props) {
   
   const buttonText = () => {
     if (session.data != undefined) {
-      let firstName = session.data.user.name.split(" ")[0]
+      let firstName = session.data.user.name.split(" ")[0].replace('-', '‑')
       // Shorten the first name if it is longer than 15 characters
       if (firstName.length > 15) {
         firstName = firstName.slice(0, 12) + "..."

--- a/app/components/layout/AppBar.js
+++ b/app/components/layout/AppBar.js
@@ -83,7 +83,7 @@ export class NavBar extends Component {
               </Box>
             </Grid>
 
-            <Grid item>
+            <Grid item sx={{ flexShrink: 1 }}>
               <SessionProvider>
                 <LoginButton />
               </SessionProvider>

--- a/app/pages/main/profile/page.js
+++ b/app/pages/main/profile/page.js
@@ -112,9 +112,8 @@ function ProfilePage() {
     }
   }, [session])
   
-  const handleUpdateData = () => {
-    
-    prismaRequest({
+  const handleUpdateData = async () => {
+    await prismaRequest({
       model: "user",
       method: "update",
       request: {
@@ -126,8 +125,8 @@ function ProfilePage() {
           lastName: lastName,
         }
       }
-    })
-    
+    });
+    window.location.reload();
   }
   
   const handleConfirmSelection = async () => {


### PR DESCRIPTION
Solves #42 
I have handled long names by making names longer than 25 characters be the first 22 chars plus "...".
One issue I can see is that "Stein Ole Knutsen" becomes just "Stein", even if the user prefers to be called "Stein Ole". However, I think this is the easiest solution in order to minimize the amount of times we have to shorten the name.
The width of the Grid containing LoginButton now automatically scales, and I have checked that it will automatically use the mobile version (where the text is below the icon, so text length doesn't cause a lot of issues) whenever making the window so small that there is almost a collision between the logo and the menu items.