### PR TITLE
Manually replaces "About CYB" with "About" on mobile

### DIFF
--- a/app/components/layout/AppBar.js
+++ b/app/components/layout/AppBar.js
@@ -163,7 +163,7 @@ function NavElementSmallScreen(item, index, iconProps, currentPath) {
                 }}
                 primary={
                   <Typography key={`link_snav${index}_typography`} variant="caption">
-                    {item.name}
+                    {item.name == "About CYB" ? "About" : item.name}
                   </Typography>
                 }
               />


### PR DESCRIPTION
Solves https://github.com/cybernetisk/internsystem-v2/issues/47
Introduces slight performance overhead due to checking all three navbar elements (excluding logo and LoginButton), but the impact is negligible.
Would need to be updated if the text for the button to /pages/main/aboutCYB is ever changed in the CMS.
I chose to search for "About CYB" instead of automatically changing the 2nd element to prevent issues if the elements are ever reordered.

The previous PR (#48) was accidentally deleted when I was cleaning up branches on my fork