### PR TITLE
Fix no result membership search

### DIFF
--- a/app/components/CustomTable.js
+++ b/app/components/CustomTable.js
@@ -76,6 +76,7 @@ function CustomTable({ headers, data, defaultFilterBy }) {
   }, [data, sortBy, sortDirection]);
 
   const filteredData = useMemo(() => {
+    setPage(0);
     return sortedData.filter((row) => {
       if (selectedSearchColumn === null || selectedFilterOption === null) {
         return true;


### PR DESCRIPTION
Fixes #66 
Set page to 0 when a search is preformed to return to the start of the filtered data