### PR TITLE
Remove temporary Halloween theme

### DIFF
--- a/app/components/Login/LoginButton.js
+++ b/app/components/Login/LoginButton.js
@@ -21,7 +21,7 @@ import { Person } from "@mui/icons-material";
 import { cybTheme } from "../themeCYB";
 import { useRouter } from "next/navigation";
 
-import { mdiGhost } from '@mdi/js';
+import { mdiPenguin } from '@mdi/js';
 import Icon from "@mdi/react";
 import Link from "next/link";
 // import { useEffect, useState } from "react";
@@ -76,7 +76,7 @@ export default function LoginButton(props) {
                 {session.status == "authenticated" ? (
                   <Icon
                     alt="Image of user"
-                    path={mdiGhost}
+                    path={mdiPenguin}
                     color={cybTheme.palette.background.main}
                   />
                 ) : (
@@ -124,7 +124,7 @@ export default function LoginButton(props) {
               {session.status == "authenticated" ? (
                 <Avatar alt="Image of user" sx={{ ...avatarProps }}>
                   <Icon
-                    path={mdiGhost}
+                    path={mdiPenguin}
                     color={cybTheme.palette.background.main}
                   />
                 </Avatar>

--- a/app/components/themeCYB.js
+++ b/app/components/themeCYB.js
@@ -5,7 +5,7 @@ export const cybTheme = createTheme({
   palette: {
     mode: "dark",
     primary: {
-      main: "#E66C2C",
+      main: "#d2a30e",
     },
     secondary: {
       main: "#ac0bce",


### PR DESCRIPTION
In #75, a temporary Halloween theme was implemented (the penguin icon was replaced by a ghost, and the primary color was changed to orange). Now it's February, so maybe we should remove that theme?