### PR TITLE
Add ability to order menu items

### DIFF
--- a/app/(pages)/(main)/board/menu/category.tsx
+++ b/app/(pages)/(main)/board/menu/category.tsx
@@ -1,14 +1,14 @@
 // This file contains react components for individual categories, and relevant utility functions.
 
-import { useEffect, useState } from "react";
-import { Button, Grid, Input, Stack, TextField, Typography } from "@mui/material";
-import { MenuCategory } from "@prisma/client";
+import {useEffect, useState} from "react";
+import {Button, Grid, Stack, TextField, Typography} from "@mui/material";
+import {MenuCategory} from "@prisma/client";
 
-import { NewProduct, Product } from "@/app/(pages)/(main)/board/menu/product";
-import { styled } from "@mui/system";
+import {NewProduct, Product, updateProduct} from "@/app/(pages)/(main)/board/menu/product";
+import {styled} from "@mui/system";
 import CircularProgress from "@mui/material/CircularProgress";
-import { DeletionConfirmationDialog } from "@/app/components/input/DeletionConfirmationDialog";
-import { MenuCategoryCreate, MenuCategoryWithProducts } from "@/app/api/utils/types/MenuCategoryTypes";
+import {DeletionConfirmationDialog} from "@/app/components/input/DeletionConfirmationDialog";
+import {MenuCategoryCreate, MenuCategoryWithProducts} from "@/app/api/utils/types/MenuCategoryTypes";
 
 
 // Updates a given category.
@@ -35,7 +35,7 @@ function createCategory(category: MenuCategoryCreate): Promise<Response> {
 }
 
 function deleteCategory(categoryId: number): Promise<Response> {
-    return fetch(`/api/v2/escape/menu/categories/${ categoryId }`, {
+    return fetch(`/api/v2/escape/menu/categories/${categoryId}`, {
         method: "DELETE",
     });
 }
@@ -84,29 +84,29 @@ export function Category(
 
     return (
         <Stack>
-            <Grid container spacing={ 2 } columns={ 10 }>
+            <Grid container spacing={2} columns={10}>
 
-                <Grid item xs={ 8 }>
+                <Grid item xs={8}>
                     <LargeTextField
                         type="text"
-                        value={ categoryName }
-                        onChange={ (e) => {
+                        value={categoryName}
+                        onChange={(e) => {
                             setCategoryName(e.target.value)
-                        } }
+                        }}
 
                         required
                         label="Category Name"
                         placeholder="Category Name"
-                        error={ categoryNameInvalid }
-                        helperText={ categoryNameInvalid ? "Name must not be empty" : "" }
+                        error={categoryNameInvalid}
+                        helperText={categoryNameInvalid ? "Name must not be empty" : ""}
 
                     ></LargeTextField>
                 </Grid>
 
-                <Grid item xs={ 1 } display="flex" alignItems="center">
+                <Grid item xs={1} display="flex" alignItems="center">
                     <Button // UPDATE button
-                        disabled={ !hasBeenUpdated || categoryNameInvalid || isUpdating }
-                        onClick={ () => {
+                        disabled={!hasBeenUpdated || categoryNameInvalid || isUpdating}
+                        onClick={() => {
                             setIsUpdating(true);
                             updateCategory(
                                 props.category,
@@ -126,12 +126,12 @@ export function Category(
                     </Button>
                 </Grid>
 
-                <Grid item xs={ 1 } display="flex" alignItems="center">
+                <Grid item xs={1} display="flex" alignItems="center">
                     <Button
                         color="error"
-                        onClick={ () => {
+                        onClick={() => {
                             setDeleteDialogOpen(true);
-                        } }
+                        }}
                     >
                         Delete
                     </Button>
@@ -139,41 +139,61 @@ export function Category(
             </Grid>
 
 
-            <Grid container spacing={ 2 } columns={ 10 }>
-
-                <Grid item xs={ 2 }>
+            <Grid container spacing={2} columns={11}>
+                {/* dummy element for alignment */}
+                <Grid item xs={1}></Grid>
+                <Grid item xs={2}>
                     <Typography variant="h5">Name</Typography>
                 </Grid>
-                <Grid item xs={ 2 }>
+                <Grid item xs={2}>
                     <Typography variant="h5">Price</Typography>
                 </Grid>
-                <Grid item xs={ 2 }>
+                <Grid item xs={2}>
                     <Typography variant="h5">Volume (cL)</Typography>
                 </Grid>
-                <Grid item xs={ 3 }>
-                    <div></div>
-                </Grid>
+                <Grid item xs={4}></Grid>
 
                 {
-                    props.category.menu_products.map((item) => (
-                            <Product product={ item } key={ item.id } onUpdate={ props.onUpdate }></Product>
+                    props.category.menu_products.map((item, index) => (
+                            <Product
+                                product={item}
+                                key={item.id}
+                                onUpdate={props.onUpdate}
+                                onMove={
+                                    (direction) => {
+                                        let delta = direction === "up" ? -1 : 1;
+                                        let toSwapWith = props.category.menu_products[index + delta];
+                                        if (!toSwapWith)
+                                            return;
+
+                                        updateProduct(item, {ordering: toSwapWith.ordering}).then(
+                                            () => {
+                                                updateProduct(toSwapWith, {ordering: item.ordering}).then(() => {
+                                                    props.onUpdate();
+                                                })
+                                            }
+                                        )
+                                    }
+                                }
+                            ></Product>
                         )
                     )
                 }
-
-                <NewProduct onUpdate={ props.onUpdate } categoryId={ props.category.id }></NewProduct>
+                {/* dummy element for alignment */}
+                <Grid item xs={1}></Grid>
+                <NewProduct onUpdate={props.onUpdate} categoryId={props.category.id}></NewProduct>
             </Grid>
 
             <DeletionConfirmationDialog
-                open={ deleteDialogOpen }
-                onClose={ () => setDeleteDialogOpen(false) }
-                onDelete={ () => {
+                open={deleteDialogOpen}
+                onClose={() => setDeleteDialogOpen(false)}
+                onDelete={() => {
                     setIsDeleting(true);
                     deleteCategory(props.category.id).then(() => {
                         props.onUpdate();
                     });
-                } }
-                showSpinner={ isDeleting }
+                }}
+                showSpinner={isDeleting}
                 title="Delete category?"
             >
                 Are you sure you want to delete this category?
@@ -216,28 +236,28 @@ export function NewCategory(props: { onUpdate: () => void }) {
     };
 
     return (
-        <Stack justifyContent="space-between" spacing={ 2 }>
+        <Stack justifyContent="space-between" spacing={2}>
             <Typography variant="h3">New Category</Typography>
 
             <TextField
                 type="text"
-                value={ categoryName }
+                value={categoryName}
                 placeholder="Category Name"
                 label="Category Name"
-                onChange={ (e) => setCategoryName(e.target.value) }
-                style={ {fontSize: "3.75rem"} }
+                onChange={(e) => setCategoryName(e.target.value)}
+                style={{fontSize: "3.75rem"}}
 
                 required
-                error={ invalid && hasBeenUpdated}
-                helperText={ invalid && hasBeenUpdated ? "Name must not be empty" : "" }
+                error={invalid && hasBeenUpdated}
+                helperText={invalid && hasBeenUpdated ? "Name must not be empty" : ""}
             ></TextField>
 
             <Button
 
-                disabled={ invalid || !hasBeenUpdated }
+                disabled={invalid || !hasBeenUpdated}
 
-                onClick={ createNewCategory }
-            >{ isCreating ? <CircularProgress/> : <>Create</> }</Button>
+                onClick={createNewCategory}
+            >{isCreating ? <CircularProgress/> : <>Create</>}</Button>
 
 
         </Stack>

--- a/app/(pages)/(main)/board/menu/category.tsx
+++ b/app/(pages)/(main)/board/menu/category.tsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react";
 import {Button, Grid, Stack, TextField, Typography} from "@mui/material";
 import {MenuCategory} from "@prisma/client";
 
-import {NewProduct, Product, updateProduct} from "@/app/(pages)/(main)/board/menu/product";
+import {NewProduct, Product, swapProductOrder, updateProduct} from "@/app/(pages)/(main)/board/menu/product";
 import {styled} from "@mui/system";
 import CircularProgress from "@mui/material/CircularProgress";
 import {DeletionConfirmationDialog} from "@/app/components/input/DeletionConfirmationDialog";
@@ -165,14 +165,10 @@ export function Category(
                                         let toSwapWith = props.category.menu_products[index + delta];
                                         if (!toSwapWith)
                                             return;
-
-                                        updateProduct(item, {ordering: toSwapWith.ordering}).then(
-                                            () => {
-                                                updateProduct(toSwapWith, {ordering: item.ordering}).then(() => {
-                                                    props.onUpdate();
-                                                })
-                                            }
-                                        )
+                                        swapProductOrder(item.id, toSwapWith.id)
+                                            .then(() => {
+                                                props.onUpdate();
+                                            });
                                     }
                                 }
                             ></Product>

--- a/app/(pages)/(main)/board/menu/product.tsx
+++ b/app/(pages)/(main)/board/menu/product.tsx
@@ -1,11 +1,11 @@
-import { MenuProduct } from "@prisma/client";
-import { useEffect, useState } from "react";
-import { Button, Checkbox, FormControlLabel, Grid, TextField, Tooltip } from "@mui/material";
+import {MenuProduct} from "@prisma/client";
+import {useEffect, useState} from "react";
+import {Button, Checkbox, FormControlLabel, Grid, Stack, TextField, Tooltip} from "@mui/material";
 import CircularProgress from "@mui/material/CircularProgress";
-import { DeletionConfirmationDialog } from "@/app/components/input/DeletionConfirmationDialog";
-import { MenuProductCreate } from "@/app/api/utils/types/MenuProductTypes";
+import {DeletionConfirmationDialog} from "@/app/components/input/DeletionConfirmationDialog";
+import {MenuProductCreate} from "@/app/api/utils/types/MenuProductTypes";
 
-function updateProduct(product: MenuProduct, newAttributes: Partial<MenuProduct>): Promise<Response> {
+export function updateProduct(product: MenuProduct, newAttributes: Partial<MenuProduct>): Promise<Response> {
     return fetch("/api/v2/escape/menu/products", {
         method: "PATCH",
         headers: {
@@ -26,7 +26,7 @@ function createProduct(product: MenuProductCreate): Promise<Response> {
 }
 
 function deleteProduct(productId: number): Promise<Response> {
-    return fetch(`/api/v2/escape/menu/products/${ productId }`, {
+    return fetch(`/api/v2/escape/menu/products/${productId}`, {
         method: "DELETE",
         headers: {
             "Content-Type": "application/json",
@@ -34,7 +34,7 @@ function deleteProduct(productId: number): Promise<Response> {
     });
 }
 
-export function Product(props: { product: MenuProduct, onUpdate: () => void }) {
+export function Product(props: { product: MenuProduct, onUpdate: () => void, onMove: (direction: "up" | "down") => void }) {
     let [hasBeenUpdated, setHasBeenUpdated] = useState<boolean>(false);
     let [isFirst, setIsFirst] = useState<boolean>(true);
 
@@ -67,41 +67,47 @@ export function Product(props: { product: MenuProduct, onUpdate: () => void }) {
     return (
 
         <>
-            { /* shared inputs */ }
-            <ProductInputs state={ newProduct } onUpdate={ value => {
+            <Grid item xs={1}>
+                <Stack direction="column">
+                    <Button onClick={() => props.onMove("up")}>Up</Button>
+                    <Button onClick={() => props.onMove("down")}>Down</Button>
+                </Stack>
+            </Grid>
+            { /* shared inputs */}
+            <ProductInputs state={newProduct} onUpdate={value => {
                 setValid(value.valid.allValid);
                 setNewProduct(value);
-            } }></ProductInputs>
+            }}></ProductInputs>
 
-            <Grid item xs={ 1 }>
+            <Grid item xs={1}>
                 <Button
-                    disabled={ !valid || !hasBeenUpdated || isUpdating }
-                    onClick={ () => {
+                    disabled={!valid || !hasBeenUpdated || isUpdating}
+                    onClick={() => {
                         setIsUpdating(true);
                         updateProduct(props.product, newProduct.product).then(() => {
                             setIsUpdating(false);
                             setHasBeenUpdated(false);
                             props.onUpdate();
                         })
-                    } }
+                    }}
 
-                >{ isUpdating ? <CircularProgress/> : <>Update</> }</Button>
+                >{isUpdating ? <CircularProgress/> : <>Update</>}</Button>
             </Grid>
 
-            <Grid item xs={ 1 }>
+            <Grid item xs={1}>
 
                 <Button
                     color="error"
-                    disabled={ isUpdating }
-                    onClick={ () => setDeleteDialogOpen(true) }
+                    disabled={isUpdating}
+                    onClick={() => setDeleteDialogOpen(true)}
                 >
                     Delete
                 </Button>
 
                 <DeletionConfirmationDialog
-                    open={ deleteDialogOpen }
-                    onClose={ () => setDeleteDialogOpen(false) }
-                    onDelete={ () => {
+                    open={deleteDialogOpen}
+                    onClose={() => setDeleteDialogOpen(false)}
+                    onDelete={() => {
                         setIsDeleting(true);
                         deleteProduct(props.product.id).then(() => {
                             setIsDeleting(false);
@@ -109,9 +115,9 @@ export function Product(props: { product: MenuProduct, onUpdate: () => void }) {
 
                             props.onUpdate();
                         });
-                    } }
-                    showSpinner={ isDeleting }
-                    title={ "Delete product?" }
+                    }}
+                    showSpinner={isDeleting}
+                    title={"Delete product?"}
                 >
                     Are you sure you want to delete this product?
                 </DeletionConfirmationDialog>
@@ -167,11 +173,11 @@ function ProductInputs(
 
     return (
         <>
-            <Grid item xs={ 2 }>
+            <Grid item xs={2}>
                 <TextField
                     type="text"
-                    value={ product.name }
-                    onChange={ e => { // all the inputs here are essentially the same.
+                    value={product.name}
+                    onChange={e => { // all the inputs here are essentially the same.
                         const newProduct = {...product, name: e.target.value}; // create new product.
                         props.onUpdate( // propagate upwards.
                             {
@@ -179,23 +185,23 @@ function ProductInputs(
                                 product: newProduct
                             }
                         );
-                    } }
+                    }}
 
                     label="Product Name"
                     placeholder="Product Name"
 
 
-                    error={ !props.state.valid.name && validateInputs }
-                    helperText={ !props.state.valid.name && validateInputs ? "Name must be set" : "" }
+                    error={!props.state.valid.name && validateInputs}
+                    helperText={!props.state.valid.name && validateInputs ? "Name must be set" : ""}
                 ></TextField>
             </Grid>
 
 
-            <Grid item xs={ 2 }>
+            <Grid item xs={2}>
                 <TextField
                     type="number"
-                    value={ product.price }
-                    onChange={ e => {
+                    value={product.price}
+                    onChange={e => {
                         const newProduct = {...product, price: Number(e.target.value)};
                         props.onUpdate(
                             {
@@ -203,20 +209,20 @@ function ProductInputs(
                                 product: newProduct
                             }
                         );
-                    } }
+                    }}
 
                     placeholder="Product Price"
                     label="Product Price"
-                    error={ !props.state.valid.price && validateInputs }
-                    helperText={ !props.state.valid.price && validateInputs ? "Price must be greater than 0" : "" }
+                    error={!props.state.valid.price && validateInputs}
+                    helperText={!props.state.valid.price && validateInputs ? "Price must be greater than 0" : ""}
                 ></TextField>
             </Grid>
 
-            <Grid item xs={ 2 }>
+            <Grid item xs={2}>
                 <TextField
                     type="number"
-                    value={ product.volume }
-                    onChange={ e => {
+                    value={product.volume}
+                    onChange={e => {
                         const newProduct = {...product, volume: Number(e.target.value)};
                         props.onUpdate(
                             {
@@ -224,23 +230,23 @@ function ProductInputs(
                                 product: newProduct
                             }
                         );
-                    } }
+                    }}
 
                     label="Volume (cL)"
                     placeholder="Volume (cL)"
 
-                    error={ !props.state.valid.volume && validateInputs }
-                    helperText={ !props.state.valid.volume && validateInputs ? "Volume must be greater than 0" : "" }
+                    error={!props.state.valid.volume && validateInputs}
+                    helperText={!props.state.valid.volume && validateInputs ? "Volume must be greater than 0" : ""}
                 ></TextField>
             </Grid>
 
-            <Grid item xs={ 1 } display="flex" justifyContent="center" alignItems="center">
+            <Grid item xs={1} display="flex" justifyContent="center" alignItems="center">
                 <FormControlLabel
                     control={
                         <Checkbox
-                            checked={ product.glutenfree }
+                            checked={product.glutenfree}
 
-                            onChange={ e => {
+                            onChange={e => {
                                 const newProduct = {...product, glutenfree: e.target.checked};
                                 props.onUpdate(
                                     {
@@ -248,21 +254,21 @@ function ProductInputs(
                                         product: newProduct
                                     }
                                 );
-                            } }
+                            }}
                         />
                     }
-                    label={ "Gluten-free" }
+                    label={"Gluten-free"}
                 />
             </Grid>
 
-            <Grid item xs={ 1 } display="flex" justifyContent="center" alignItems="center">
+            <Grid item xs={1} display="flex" justifyContent="center" alignItems="center">
                 <Tooltip title="If this is checked, the item is hidden from the menu.">
                     <FormControlLabel
                         control={
                             <Checkbox
-                                checked={ product.hidden }
+                                checked={product.hidden}
 
-                                onChange={ e => {
+                                onChange={e => {
                                     const newProduct = {...product, hidden: e.target.checked};
                                     props.onUpdate(
                                         {
@@ -270,7 +276,7 @@ function ProductInputs(
                                             product: newProduct
                                         }
                                     );
-                                } }
+                                }}
                             />
                         }
                         label="Hidden"
@@ -319,14 +325,14 @@ export function NewProduct(props: { onUpdate: () => void, categoryId: number | n
 
     return (
         <>
-            <ProductInputs validateInputs={ hasBeenUpdated } state={ newProduct } onUpdate={ (value) => {
+            <ProductInputs validateInputs={hasBeenUpdated} state={newProduct} onUpdate={(value) => {
                 setNewProduct(value);
 
-            } }/>
+            }}/>
 
-            <Grid item xs={ 1 }>
-                <Button disabled={ !newProduct.valid.allValid || isCreating }
-                        onClick={ () => {
+            <Grid item xs={1}>
+                <Button disabled={!newProduct.valid.allValid || isCreating}
+                        onClick={() => {
                             setIsCreating(true);
                             createProduct({
                                 ...newProduct.product,
@@ -341,9 +347,9 @@ export function NewProduct(props: { onUpdate: () => void, categoryId: number | n
                                 props.onUpdate();
                             });
 
-                        } }
+                        }}
 
-                >{ isCreating ? <CircularProgress/> : <>Create</> }</Button>
+                >{isCreating ? <CircularProgress/> : <>Create</>}</Button>
 
             </Grid>
         </>

--- a/app/(pages)/(main)/board/menu/product.tsx
+++ b/app/(pages)/(main)/board/menu/product.tsx
@@ -34,7 +34,24 @@ function deleteProduct(productId: number): Promise<Response> {
     });
 }
 
-export function Product(props: { product: MenuProduct, onUpdate: () => void, onMove: (direction: "up" | "down") => void }) {
+export function swapProductOrder(swapId: number, withId: number): Promise<Response> {
+    return fetch(`/api/v2/escape/menu/products/ordering`, {
+        method: "PATCH",
+        body: JSON.stringify({
+            swapId,
+            withId
+        }),
+        headers: {
+            "Content-Type": "application/json",
+        }
+    });
+}
+
+export function Product(props: {
+    product: MenuProduct,
+    onUpdate: () => void,
+    onMove: (direction: "up" | "down") => void
+}) {
     let [hasBeenUpdated, setHasBeenUpdated] = useState<boolean>(false);
     let [isFirst, setIsFirst] = useState<boolean>(true);
 

--- a/app/(pages)/(main)/escape/menu/page.tsx
+++ b/app/(pages)/(main)/escape/menu/page.tsx
@@ -11,6 +11,9 @@ export default async function EscapeMenu() {
             menu_products: {
                 where: {
                     hidden: false
+                },
+                orderBy: {
+                    ordering: "asc"
                 }
             }
         }

--- a/app/api/utils/types/MenuProductTypes.ts
+++ b/app/api/utils/types/MenuProductTypes.ts
@@ -1,3 +1,8 @@
 import { Prisma } from "@prisma/client";
 
 export type MenuProductCreate = Prisma.MenuProductCreateArgs["data"]
+
+export interface MenuProductSwapOrderingRequestData {
+    swapId: number;
+    withId: number;
+}

--- a/app/api/v2/escape/menu/products/ordering/route.ts
+++ b/app/api/v2/escape/menu/products/ordering/route.ts
@@ -1,0 +1,49 @@
+import {getServerSession} from "next-auth";
+import {authOptions} from "@/app/api/utils/authOptions";
+import {Auth} from "@/app/api/utils/auth";
+import {NextRequest, NextResponse} from "next/server";
+import {MenuProductSwapOrderingRequestData} from "@/app/api/utils/types/MenuProductTypes";
+import prisma from "@/prisma/prismaClient";
+
+export async function PATCH(
+    req: NextRequest
+) {
+    const params: MenuProductSwapOrderingRequestData = await req.json();
+
+    const session = await getServerSession(authOptions);
+    const auth = new Auth(session, params)
+        .requireRoles(["board"])
+        .requireParams(["swapId", "withId"]);
+
+    await prisma.$transaction(async (tx) => {
+        const swap = await prisma.menuProduct.findFirst({
+            where: {id: params.swapId}
+        });
+        const withProduct = await prisma.menuProduct.findFirst({
+            where: {id: params.withId}
+        });
+
+        // swap ordering
+        await tx.menuProduct.update({
+            where: {
+                id: swap.id
+            },
+            data: {
+                ordering: withProduct.ordering
+            }
+        });
+        await tx.menuProduct.update({
+            where: {
+                id: withProduct.id
+            },
+            data: {
+                ordering: swap.ordering
+            }
+        });
+    });
+
+
+    return auth.verify(
+        NextResponse.json({})
+    );
+}

--- a/app/api/v2/escape/menu/products/route.ts
+++ b/app/api/v2/escape/menu/products/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import {NextRequest, NextResponse} from "next/server";
 import prisma from "@/prisma/prismaClient";
 import prismaClient from "@/prisma/prismaClient";
-import { MenuProduct } from "@prisma/client";
-import { authOptions } from "@/app/api/utils/authOptions";
-import { getServerSession } from "next-auth";
-import { Auth } from "@/app/api/utils/auth";
-import { MenuProductCreate } from "@/app/api/utils/types/MenuProductTypes";
+import {MenuProduct} from "@prisma/client";
+import {authOptions} from "@/app/api/utils/authOptions";
+import {getServerSession} from "next-auth";
+import {Auth} from "@/app/api/utils/auth";
+import {MenuProductCreate} from "@/app/api/utils/types/MenuProductTypes";
 
 
 // Modify a product. Modifies the product based on the id in the request body.
@@ -32,7 +32,7 @@ export async function PATCH(
         return auth.verify(NextResponse.json(JSON.stringify(newProduct)));
     } catch (e) {
         return auth.verify(NextResponse.json(
-            {error: `something went wrong: ${ e }`},
+            {error: `something went wrong: ${e}`},
             {status: 500}
         ));
     }
@@ -53,15 +53,24 @@ export async function POST(
     if (auth.failed) return auth.response;
 
     try {
-        await prisma.menuProduct.create({
+        const newProduct = await prisma.menuProduct.create({
             data: product
         });
+        // set the ordering to the product's id to make the ordering system work
+        await prisma.menuProduct.update({
+            where: {
+                id: newProduct.id
+            },
+            data: {
+                ordering: newProduct.id
+            }
+        })
 
         // 201 Created
         return auth.verify(NextResponse.json(JSON.stringify({}), {status: 201}));
     } catch (e) {
         return auth.verify(NextResponse.json(
-            {error: `something went wrong: ${ e }`},
+            {error: `something went wrong: ${e}`},
             {status: 500}
         ));
     }

--- a/app/api/v2/escape/menu/route.ts
+++ b/app/api/v2/escape/menu/route.ts
@@ -1,21 +1,27 @@
 import prisma from "@/prisma/prismaClient";
-import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { Auth } from "@/app/api/utils/auth";
-import { authOptions } from "@/app/api/utils/authOptions";
+import {NextResponse} from "next/server";
+import {getServerSession} from "next-auth";
+import {Auth} from "@/app/api/utils/auth";
+import {authOptions} from "@/app/api/utils/authOptions";
+import {MenuCategoryWithProducts} from "@/app/api/utils/types/MenuCategoryTypes";
 
 // Gets the whole menu
 export async function GET(): Promise<NextResponse> {
     const session = getServerSession(authOptions);
     const auth = new Auth(session);
 
-    let menuCategories = await prisma.menuCategory.findMany(
+    let menuCategories: MenuCategoryWithProducts[] = await prisma.menuCategory.findMany(
         {
             include: {
-                menu_products: true
+                menu_products: {
+                    orderBy: [
+                        {ordering: "asc"},
+                        {id: "asc"}
+                    ]
+                }
             }
         }
     );
-    
+
     return auth.verify(NextResponse.json(menuCategories));
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,7 @@ model MenuProduct {
   hidden         Boolean       @default(false)
   category_id    Int
   category       MenuCategory? @relation("MenuProduct_category", fields: [category_id], references: [id])
+  ordering       Int?
 }
 
 model old_users {


### PR DESCRIPTION
Closes #118 

Pretty quick and dirty; ~~there is essentially no error handling if something goes wrong when ordering the items. Categories cannot be ordered yet~~ (somewhat fixed in db8ab8f851694c72396b407c0cfaaf2628530e90).

<img width="1987" height="1017" alt="image" src="https://github.com/user-attachments/assets/ab5d011a-9694-4e97-a2d9-d3d5a722ea92" />
The "UP"/"DOWN" buttons on the left are used to order the items.


### IMPORTANT
This snippet of SQL needs to be run after migrating the database for it to behave correctly: `UPDATE MenuProduct SET ordering=id WHERE ordering IS NULL;`
