### PR TITLE
fix: replace GrayText system color for Safari compatibility

### DIFF
--- a/app/(pages)/(main)/aboutCYB/page.js
+++ b/app/(pages)/(main)/aboutCYB/page.js
@@ -112,7 +112,7 @@ const card = (list) => {
             <Typography
               variant="subtitle2"
               key={"card_content_t2_" + p.title}
-              color="GrayText"
+              color="text.secondary"
               gutterBottom
             >
               {p.name ? p.name : ":("}

--- a/app/components/calendar/CafeShiftScheduler.js
+++ b/app/components/calendar/CafeShiftScheduler.js
@@ -72,7 +72,7 @@ export default function CafeShiftScheduler(props) {
     setFocusedDay(modeOperations[mode](focusedDay, 1));
   }
 
-  const getDayColor = (day, check, inactiveColor="GrayText") => {
+  const getDayColor = (day, check, inactiveColor="text.secondary") => {
     if (isToday(day)) return cybTheme.palette.primary.main;
     if (!check(day, focusedDay)) return inactiveColor;
     return "";

--- a/app/components/input/CustomAutocomplete.js
+++ b/app/components/input/CustomAutocomplete.js
@@ -107,7 +107,7 @@ export default class CustomAutoComplete extends Component {
                   <Typography
                     key={`option_box_email_${props.id}`}
                     variant="caption"
-                    color="GrayText"
+                    color="text.secondary"
                   >
                     {option[subDataLabel]}
                   </Typography>

--- a/app/components/input/CustomMultiAutocomplete.js
+++ b/app/components/input/CustomMultiAutocomplete.js
@@ -95,7 +95,7 @@ export default class CustomMultiAutoComplete extends Component {
                   <Typography
                     key={`option_box_email_${props.id}`}
                     variant="caption"
-                    color="GrayText"
+                    color="text.secondary"
                   >
                     {option[subDataLabel]}
                   </Typography>


### PR DESCRIPTION
## Summary
- Safari renders the CSS system color keyword `GrayText` inconsistently with other browsers (often as black or an unrelated color), making grey text look weird.
- Replace `color=\"GrayText\"` with MUI's theme-aware `color=\"text.secondary\"` in four spots (Typography props + the `getDayColor` default in `CafeShiftScheduler`).

## Test plan
- [ ] Open the affected views in Safari and Chrome and confirm secondary text now renders in a consistent grey:
  - `aboutCYB` page (member name under each card)
  - `CustomAutocomplete` / `CustomMultiAutocomplete` option dropdowns (sub-label rows)
  - `CafeShiftScheduler` calendar (inactive days outside the focused month/week)